### PR TITLE
Delete the problematic float80 because it intermittently throws build…

### DIFF
--- a/Sources/CommonExtensions/BinaryInteger.swift
+++ b/Sources/CommonExtensions/BinaryInteger.swift
@@ -22,9 +22,6 @@ public extension BinaryInteger {
     var float:   Float   { floatingPoint() }
 
     var double:  Double  { floatingPoint() }
-
-    @available(macOS 10.10, *)
-    var float80: Float80 { floatingPoint() }
 }
 
 


### PR DESCRIPTION
… time errors on ios.